### PR TITLE
CMakeLists.txt: Build Debug by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,9 @@ project(sota_client_cpp)
 option(WARNING_AS_ERROR "Treat warnings as errors" ON)
 option(BUILD_WITH_CODE_COVERAGE "Enable gcov code coverage" OFF)
 
-set(CMAKE_BUILD_TYPE Debug)
+IF( NOT CMAKE_BUILD_TYPE )
+    set(CMAKE_BUILD_TYPE Debug)
+ENDIF()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 OPTION(BUILD_WITH_DBUS_GATEWAY "Set to ON to compile with dbus gateway support" OFF)


### PR DESCRIPTION
The following change allows to switch from Debug
to Release mode building the application through
-DCMAKE_BUILD_TYPE. The default mode remains
Debug.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>